### PR TITLE
Fix API page TOC alignment

### DIFF
--- a/api.html
+++ b/api.html
@@ -11,7 +11,7 @@ layout: default
 <ul><li><a href="#method-dictionary">Dictionary</a></li>
 <li><a href="#method-law">Law</a></li>
 <li><a href="#method-search">Search</a></li>
-<li><a href="#method-structure">Structure</a></li></ul></li>
+<li><a href="#method-structure">Structure</a></li>
 <li><a href="#method-suggest">Suggest</a></li></ul></li>
 <li><a href="#errors">Errors</a></li>
 </ul>

--- a/api.html
+++ b/api.html
@@ -8,11 +8,14 @@ layout: default
 <ul>
 <li><a href="#how-to">How to...</a></li>
 <li><a href="#methods">Methods</a>
-<ul><li><a href="#method-dictionary">Dictionary</a></li>
-<li><a href="#method-law">Law</a></li>
-<li><a href="#method-search">Search</a></li>
-<li><a href="#method-structure">Structure</a></li>
-<li><a href="#method-suggest">Suggest</a></li></ul></li>
+  <ul>
+    <li><a href="#method-dictionary">Dictionary</a></li>
+    <li><a href="#method-law">Law</a></li>
+    <li><a href="#method-search">Search</a></li>
+    <li><a href="#method-structure">Structure</a></li>
+    <li><a href="#method-suggest">Suggest</a></li>
+  </ul>
+</li>
 <li><a href="#errors">Errors</a></li>
 </ul>
 


### PR DESCRIPTION
The API page TOC alignment was slightly off due to rogue `</ul>` and `</li>` tags; removed them. Slight formatting added to HTML for readability.

Screenshot of off alignment: http://pasteboard.co/1cVB6ONd.jpg
